### PR TITLE
Add nearest-neighbour surface scaling

### DIFF
--- a/bflibrary/include/bfscreen.h
+++ b/bflibrary/include/bfscreen.h
@@ -218,9 +218,9 @@ struct DisplayStruct { // sizeof=118
      *  LbPaletteGet() should be used to retrieve a copy of the palette. */
     ubyte *Palette; // offset=114
 #if defined(ENABLE_MOUSE_WHEEL)
-    short WhellPosition;
-    ushort WhellMoveUp;
-    ushort WhellMoveDown;
+    short WheelPosition;
+    ushort WheelMoveUp;
+    ushort WheelMoveDown;
 #endif
 #if defined(ENABLE_MOUSE_MOVE_RATIO)
     short MouseMoveRatioX;
@@ -256,6 +256,12 @@ struct ScreenModeInfo { // sizeof=38
     char Desc[24]; // offset=14
 };
 
+typedef struct SurfaceDimensions TbSurfaceDimensions;
+
+struct SurfaceDimensions {
+    long Width, Height;
+};
+
 typedef const char *(*ResourceMappingFunc)(short);
 
 #pragma pack()
@@ -272,6 +278,9 @@ extern long lbScreenModeInfoNum;
 
 extern TbDisplayStruct lbDisplay;
 extern DwBool lbScreenInitialised;
+
+/* Used to transform mouse position when screen surface scaling is applied */
+extern TbSurfaceDimensions lbScreenSurfaceDimensions;
 
 /** True if we have two surfaces. */
 extern TbBool lbHasSecondSurface;
@@ -306,22 +315,23 @@ TbScreenMode LbRegisterVideoMode(const char *desc,
     TbScreenCoord width, TbScreenCoord height,
     ushort bpp, ulong flags);
 
-/** Set minimal value of dimensions in physical resolution.
+/** Set minimal value of screen surface width and height
  *
- *  On a try to setup lower resolution, the library will use pixel doubling
- *  to reach the minimal size for both dimensions. This mechanism should
- *  be used to rescale games which do not have resolution change implemented
- *  within them - when games are remade well enough to allow resolution
- *  control from config files, it is better to leave this feature inactive.
+ *  If an application requests a lower resolution, the library will use
+ *  nearest-neighbour scaling to reach the minimum width and height. This
+ *  mechanism should be used to rescale games which do not have resolution
+ *  change implemented within them - when games are remade well enough to allow
+ *  resolution control from config files, it is better to leave this feature
+ *  inactive.
  *
- *  The screen doubling is hidden within lbDisplay struct and mouse position,
- *  that is, related width/height/position values behave like there was no
- *  doubling and the screen size was smaller. This means the doubling does
- *  not require any code changes on application side, besides this call.
+ *  The scaling is invisible to the lbDisplay struct and mouse position; that
+ *  is, the related width/height/position values behave like there was no
+ *  scaling. This means that as the library performs scaling, the application
+ *  side does not need to change any behaviour as a result of this call.
  *
- *  If the values is 1, phyical screen doubling is always disabled.
+ *  If the values is 1, screen surface scaling is always disabled.
  */
-TbResult LbScreenSetMinPhysicalScreenResolution(long dim);
+TbResult LbScreenSetMinScreenSurfaceDimension(long dim);
 
 /** Set title of the application to be used in target OS.
  */

--- a/bflibrary/src/general/gmouse.c
+++ b/bflibrary/src/general/gmouse.c
@@ -117,16 +117,16 @@ TbResult mouseControl(TbMouseAction action, struct TbPoint *pos)
         break;
     case MActn_WHEELMOVEUP:
 #if defined(ENABLE_MOUSE_WHEEL)
-        lbDisplay.WhellPosition--;
-        lbDisplay.WhellMoveUp++;
-        lbDisplay.WhellMoveDown = 0;
+        lbDisplay.WheelPosition--;
+        lbDisplay.WheelMoveUp++;
+        lbDisplay.WheelMoveDown = 0;
 #endif
         break;
     case MActn_WHEELMOVEDOWN:
 #if defined(ENABLE_MOUSE_WHEEL)
-        lbDisplay.WhellPosition++;
-        lbDisplay.WhellMoveUp = 0;
-        lbDisplay.WhellMoveDown++;
+        lbDisplay.WheelPosition++;
+        lbDisplay.WheelMoveUp = 0;
+        lbDisplay.WheelMoveDown++;
 #endif
         break;
     default:

--- a/bflibrary/src/x86-win-sdl/smouse.cpp
+++ b/bflibrary/src/x86-win-sdl/smouse.cpp
@@ -27,11 +27,10 @@
 #include "bfplanar.h"
 #include "privbflog.h"
 
+
 extern "C" {
 
 #define AUTORESET_MIN_SHIFT 50
-
-extern long lbPhysicalResolutionMul;
 
 };
 
@@ -291,11 +290,12 @@ void MouseToScreen(struct TbPoint *pos)
       my = orig.y;
     }
 
-    if ((lbPhysicalResolutionMul > 1) && lbHasSecondSurface)
-    {
-        pos->x = pos->x / lbPhysicalResolutionMul;
-        pos->y = pos->y / lbPhysicalResolutionMul;
-    }
+    if (lbScreenSurfaceDimensions.Width != lbDisplay.GraphicsScreenWidth)
+        pos->x = (pos->x * lbDisplay.GraphicsScreenWidth) /
+            lbScreenSurfaceDimensions.Width;
+    if (lbScreenSurfaceDimensions.Height != lbDisplay.GraphicsScreenHeight)
+        pos->y = (pos->y * lbDisplay.GraphicsScreenHeight) /
+            lbScreenSurfaceDimensions.Height;
     LOGNO("before (%ld,%ld) after (%ld,%ld)", orig.x, orig.y, pos->x, pos->y);
 }
 

--- a/bflibrary/tests/mock_screen.c
+++ b/bflibrary/tests/mock_screen.c
@@ -28,8 +28,8 @@
 #include "bfutility.h"
 #include "bftstlog.h"
 
-extern long lbPhysicalResolutionMul;
-extern long lbMinPhysicalScreenResolutionDim;
+extern long lbMinScreenSurfaceDimension;
+
 
 TbResult MockScreenFindVideoModes(void)
 {
@@ -88,18 +88,18 @@ TbResult MockScreenSetupAnyMode(TbScreenMode mode, TbScreenCoord width,
             (int)mdinfo->Width, (int)mdinfo->Height, (int)mode);
         return Lb_FAIL;
     }
-
+    mdWidth = mdinfo->Width;
+    mdHeight = mdinfo->Height;
     {
-        long minDim = min(mdinfo->Width,mdinfo->Height);
-        if ((minDim != 0) && (minDim < lbMinPhysicalScreenResolutionDim)) {
-            lbPhysicalResolutionMul = (lbMinPhysicalScreenResolutionDim + minDim - 1) / minDim;
-        } else {
-            lbPhysicalResolutionMul = 1;
+        const long minD = min(mdWidth, mdHeight);
+        if (minD != 0 && minD < lbMinScreenSurfaceDimension) {
+            mdWidth = lbScreenSurfaceDimensions.Width =
+                lbMinScreenSurfaceDimension * mdWidth / minD;
+            mdHeight = lbScreenSurfaceDimensions.Height =
+                lbMinScreenSurfaceDimension * mdHeight / minD;
         }
-        mdWidth = mdinfo->Width * lbPhysicalResolutionMul;
-        mdHeight = mdinfo->Height * lbPhysicalResolutionMul;
-        LOGDBG("physical resolution multiplier %ld", lbPhysicalResolutionMul);
     }
+    LOGDBG("screen surface dimensions set to %ldx%ld", mdWidth, mdHeight);
     lbDisplay.VesaIsSetUp = false;
 
     lbScreenSurface = lbDrawSurface = (OSSurfaceHandle)malloc(mdWidth *

--- a/src/display.c
+++ b/src/display.c
@@ -79,7 +79,7 @@ display_set_full_screen (bool full_screen)
     if (lbScreenSurface != NULL)
         return;
 
-    for (i = 1; i < 99; i++)
+    for (i = 1; i < LB_MAX_SCREEN_MODES_COUNT; ++i)
     {
         TbScreenModeInfo *mdinfo;
 
@@ -97,9 +97,9 @@ void
 display_set_lowres_stretch (bool stretch)
 {
   if (stretch)
-      LbScreenSetMinPhysicalScreenResolution(400);
+      LbScreenSetMinScreenSurfaceDimension(400);
   else
-      LbScreenSetMinPhysicalScreenResolution(1);
+      LbScreenSetMinScreenSurfaceDimension(1);
 }
 
 void


### PR DESCRIPTION
As per the commit message; I implemented a software nearest-neighbour scaling so that any resolution could be scaled to (for the x86-win-sdl library).

I swapped the minimum resolution parameter for a minimum height parameter; if the application calls for a screen which has fewer rows than the minimum specified - then the library scales up the resolution to the minimum height (while maintaining aspect ratio requested).

In full-screen mode, this can result in SDL choosing different resolutions and placing the (scaled to minimum height) screen surface in the middle - but for most heights that ppl would choose this shouldn't be a problem.

If nothing else - hope it inspires some future changes.